### PR TITLE
feat: make nested fields required based on parent question for memorable date custom component

### DIFF
--- a/src/app/components/survey.creator/survey.creator.component.ts
+++ b/src/app/components/survey.creator/survey.creator.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { SurveyCreatorModel } from "survey-creator-core";
 import * as SurveyCore from 'survey-core';
 import { SurveyCreatorModule } from "survey-creator-angular";
-import { ComponentCollection, SvgRegistry, Serializer } from 'survey-core';
+import { ComponentCollection, QuestionCompositeModel, SvgRegistry, Serializer } from 'survey-core';
 import { Converter } from "showdown";
 import { surveyJson } from '../../../assets/survey.json';
 import "survey-core/survey.i18n.js";
@@ -48,7 +48,7 @@ ComponentCollection.Instance.add({
       name: "birthMonth",
       title: "Month",
       titleLocation: "top",
-      isRequired: true,
+      isRequired: false,
       width: "230px",
       minWidth: "230px",
       maxWidth: "230px",
@@ -114,7 +114,7 @@ ComponentCollection.Instance.add({
       name: "birthDay",
       title: "Day",
       titleLocation: "top",
-      isRequired: true,
+      isRequired: false,
       width: "130px",
       minWidth: "130px",
       maxWidth: "130px",
@@ -128,14 +128,29 @@ ComponentCollection.Instance.add({
       name: "birthYear",
       title: "Year",
       titleLocation: "top",
-      isRequired: true,
+      isRequired: false,
       width: "130px",
       minWidth: "130px",
       maxWidth: "130px",
       startWithNewLine: false,
     },
   ],
+  onCreated(question: QuestionCompositeModel) {
+    updateIsRequired(question);
+  },
+  onLoaded(question: QuestionCompositeModel) {
+    updateIsRequired(question);
+  },
+  onPropertyChanged(question: QuestionCompositeModel, propertyName: string) {
+    if (propertyName === "isRequired") {
+      updateIsRequired(question);
+    }
+  },
 });
+
+function updateIsRequired(question: QuestionCompositeModel) {
+  question.contentPanel.questions.forEach(q => q.isRequired = question.isRequired);
+}
 
 @Component({
   selector: 'app-survey-creator',

--- a/src/assets/survey.json.ts
+++ b/src/assets/survey.json.ts
@@ -141,6 +141,7 @@ export const surveyJson = {
          {
             "type": "memorabledate",
             "name": "birthDatePanel",
+            "isRequired": true
          },
          {
           "type": "radiogroup",


### PR DESCRIPTION
### Description

Update the memorable date custom component to make the 3 nested fields not required by default, and to update the required property based on whether the entire outer component is required. This requires implementing several methods within the [custom question configuration](https://surveyjs.io/form-library/documentation/api-reference/icustomquestiontypeconfiguration).

If we don't implement these methods and simply toggle "required" to true for the memorable date instance, the validation requires us to set some value, but setting any one of the 3 child fields gets rid of the error, which is not what we want since we want all 3 of them to be required in this case.
<img width="720" alt="Screenshot 2024-05-06 at 4 43 48 PM" src="https://github.com/codeforamerica/surveyjs-creator-angular/assets/67125998/8d894d77-f90a-4188-94cc-bdce8f78dc5d">

With the changes in this PR, setting "required" to true for the memorable date instance makes each of the 3 child components required, whether this is done via updating the JSON or by checking the required box in the UI. Additionally, the UI updates to show the red asterisks for the required fields in real time. You can watch the screen recording below for a quick demo of the UI changes + the validation.

https://github.com/codeforamerica/surveyjs-creator-angular/assets/67125998/57aa43f1-7f92-406d-9175-25260ad8845b

You can see in the demo that if none of the child fields are set, we get 4 error messages: one for each of the fields and an additional one for the outer field. If this is not desirable and we only want the child error messages, I can explore changing this.