### PR TITLE
style: style the navigation buttons like primary buttons in the CfA USWDS theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -79,3 +79,21 @@
         outline: 0.25rem solid #e5a000;
     }
 }
+
+.sd-body__navigation .sd-navigation__prev-btn {
+    background-color: white;
+    color: #171716;
+    box-shadow: inset 0 0 0 2px #171716;
+
+    &:hover {
+        background-color: #f5f5f0;
+    }
+
+    &:active {
+        background-color: #f5f5f0;
+    }
+
+    &:focus {
+        outline: 0.25rem solid #e5a000;
+    }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,3 +56,26 @@
     margin-bottom: .5rem;
     margin-top: 0;
 }
+
+.sd-body__navigation .sd-btn {
+    background-color: #2e8367;
+    color: white;
+    border-radius: 0.5rem;
+    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+    font-size: 1.06rem !important;
+    font-weight: 700;
+    padding: 1rem 1.25rem !important;
+    margin-right: .5rem;
+
+    &:hover {
+        background-color: #0b4b3f;
+    }
+
+    &:active {
+        background-color: #123131;
+    }
+
+    &:focus {
+        outline: 0.25rem solid #e5a000;
+    }
+}


### PR DESCRIPTION
### Description

Style the navigation buttons to look like the [primary buttons](https://codeforamerica.github.io/uswds/components/button/#examples) in the CfA USWDS theme. The changes made are around color, font, margin, padding and borders - including hover, active and focus states.

Before
<img width="777" alt="Screenshot 2024-05-15 at 4 20 08 PM" src="https://github.com/codeforamerica/surveyjs-creator-angular/assets/67125998/a8f91ae0-90f6-4469-8f39-aaf7af50b76e">

After
<img width="718" alt="Screenshot 2024-05-15 at 4 19 31 PM" src="https://github.com/codeforamerica/surveyjs-creator-angular/assets/67125998/983a9183-d6d8-4330-af74-65238f7ec9ba">

The intent of this change is to serve as a proof of concept that components in SurveyJS can be styled to look like the CfA USWDS theme.